### PR TITLE
Allow hashed JS assets to be resolved in the HTML template

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ if (typeof document !== 'undefined') {
 module.exports = MyComponent;
 ```
 
+## Using a hashed source file
+
+### webpack.config.js
+
+```js
+var ReactToHtmlPlugin = require('react-to-html-webpack-plugin');
+
+module.exports = {
+
+  entry: {
+    main: './index.js'
+  },
+
+  output: {
+    filename: 'assets/[hash].js',
+    path: 'dist',
+    /* IMPORTANT!
+     * You must compile to UMD or CommonJS
+     * so it can be required in a Node context: */
+    library: 'MyComponentExample',
+    libraryTarget: 'umd'
+  },
+
+  module: {
+    loaders: [
+      { test: /\.jsx$/, loader: 'jsx-loader' }
+    ]
+  },
+
+  plugins: [
+    // Note: "index.js" is not used, instead use "main" which is the name of the entry
+    // Using "index.js" would result in a file not found error because it has been hashed
+    new ReactToHtmlPlugin('index.html', 'main')
+  ]
+
+};
+```
+
 ## API
 
 ```js


### PR DESCRIPTION
Here is the gist that I originally sent to @markdalgleish:

> These changes work successfully for me in resolving the correctly hashed script name for JS files in `index.html`. https://gist.github.com/jonathaningram/d1aaeb8b9314094e0d21

Note: this PR only addresses getting the right filename for the source JS file. It doesn't address sending assets like CSS to the template.
