### PR TITLE
Expose hashed CSS path to template when using ExtractTextPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ The template is called with the following data:
 {
   html: '...',
   assets: {
-    chunkName: assetPath,
-    ...
+    chunkName: {
+      js: jsAssetPath,
+      css: cssAssetPath // if you used ExtractTextPlugin to extract a CSS file as well
+    }
   }
 }
 ```
@@ -138,13 +140,16 @@ new ReactToHtmlPlugin('index.html', 'index.js', {
   template: function(data) {
     return ejs.render(`
       <html>
-        ...
+        <head>
+          ...
+          <link rel="stylesheet" href="<%= assets[chunk].css %>">
+        </head>
         <body>
           <div id="app">
             <%- html %>
           </div>
           <% for (var chunk in assets) { -%>
-          <script src="<%= assets[chunk] %>"></script>
+          <script src="<%= assets[chunk].js %>"></script>
           <% } -%>
         </body>
       </html>

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ new ReactToHtmlPlugin('index.html', 'index.js', {
       <html>
         <head>
           ...
+          <% for (var chunk in assets) { -%>
           <link rel="stylesheet" href="<%= assets[chunk].css %>">
+          <% } -%>
         </head>
         <body>
           <div id="app">

--- a/index.js
+++ b/index.js
@@ -67,23 +67,34 @@ var findAsset = function(src, compiler, webpackStatsJson) {
 // Shamelessly stolen from html-webpack-plugin - Thanks @ampedandwired :)
 var getAssetsFromCompiler = function(compiler, webpackStatsJson) {
   var assets = {};
+
   for (var chunk in webpackStatsJson.assetsByChunkName) {
     var chunkValue = webpackStatsJson.assetsByChunkName[chunk];
 
-    // Webpack outputs an array for each chunk when using sourcemaps
+    var output = {};
+
+    // Webpack outputs an array for each chunk when using sourcemaps or ExtractTextPlugin
     if (chunkValue instanceof Array) {
-      // Is the main bundle always the first element?
-      chunkValue = chunkValue[0];
+      chunkValue.forEach(function(value, index) {
+        if (value.match(/\.js$/)) {
+          output.js = withPublicPath(compiler.options.output.publicPath, value);
+        } else if (value.match(/\.css$/)) {
+          output.css = withPublicPath(compiler.options.output.publicPath, value);
+        }
+      });
+    } else {
+      output.js = withPublicPath(compiler.options.output.publicPath, chunkValue);
     }
 
-    if (compiler.options.output.publicPath) {
-      chunkValue = compiler.options.output.publicPath + chunkValue;
-    }
-    assets[chunk] = chunkValue;
+    assets[chunk] = output;
   }
 
   return assets;
 };
+
+var withPublicPath = function (publicPath, originalPath) {
+  return publicPath ? (publicPath + originalPath) : originalPath
+}
 
 var createAssetFromContents = function(contents) {
   return {


### PR DESCRIPTION
Howdy!

I'm using this plugin alongside `ExtractTextPlugin` to extract a CSS file, as well as the `template` option with EJS to generate the wrapper html document.

The `plugins` section of my webpack config looks like this:

``` js
  plugins: [
    new ExtractTextPlugin('assets/[name].[contenthash].css', {
      allChunks: true
    }),
    new ReactToHtmlPlugin('index.html', 'index', {
      template: // ... some ejs render function
    })
  ],
```

I want my stylesheet path to be exposed in `data.assets` passed to the template so I can do my stylesheet link in there.

This PR expands on #4 & changes the shape of the data that's passed to templates so it looks like this:

``` js
{
  html: '...',
  assets: {
    js: jsAssetPath,
    css: cssAssetPath
  }
}
```

I've tested this with & without `ExtractTextPlugin`, with & without sourcemaps & with multiple entrypoints.
